### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: Extension
+
+on:
+    push:
+        tags:
+            - 'v*.*.*'
+
+jobs:
+    Publish:
+        runs-on: ubuntu-latest
+        
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+            
+            - name: Install vsce
+              run: npm install -g @vscode/vsce
+            
+            - name: Extract version from tag
+              id: version
+              run: |
+                  VERSION=${GITHUB_REF#refs/tags/v}
+                  echo "version=$VERSION" >> $GITHUB_OUTPUT
+                  echo "📦 Version: $VERSION"
+            
+            - name: Update package.json version
+              run: |
+                  VERSION=${{ steps.version.outputs.version }}
+                  jq --arg version "$VERSION" '.version = $version' package.json > package.json.tmp
+                  mv package.json.tmp package.json
+                  cat package.json | grep version
+            
+            - name: Commit updated package.json
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add package.json
+                  git commit -m "Update version to ${{ steps.version.outputs.version }}"
+                  git push origin HEAD:main
+            
+            - name: Package extension
+              run: vsce package --no-git-tag-version
+            
+            - name: Get package filename
+              id: package
+              run: |
+                  VSIX_FILE=$(ls *.vsix)
+                  echo "filename=$VSIX_FILE" >> $GITHUB_OUTPUT
+                  echo "📦 Package: $VSIX_FILE"
+            
+            - name: Create GitHub Release
+              uses: softprops/action-gh-release@v2
+              with:
+                  files: ${{ steps.package.outputs.filename }}
+                  generate_release_notes: true
+                  token: ${{ secrets.GITHUB_TOKEN }}
+            
+            - name: Publish to VSCode Marketplace
+              run: vsce publish -p ${{ secrets.VSCE_TOKEN }}


### PR DESCRIPTION
The plan is...

once a `vX.Y.Z` tag is pushed:

- we validate the package, as usual
- the version will be auto-embedded in the `package.json` file (so that we don't have to
- we commit to the main branch
- package it all and publish it all as a "Release" here on GitHub
- package the extension and publish it to the VSCode Marketplace