### PR TITLE
Deprecate iconfile feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,13 +82,6 @@
         "language": "art",
         "path": "./snippets/types.json"
       }
-    ],
-    "iconThemes": [
-      {
-        "id": "art",
-        "label": "Arturo Icons",
-        "path": "icons/config.json"
-      }
     ]
   }
 }


### PR DESCRIPTION
I thought this would include arturo's icon alongside with the default ones. But I was wrong, this replaces all icons. By enabling it, we have Arturo's icons working great, but this breaks all other file icons.

See this:

|Arturo Extension Disabled|Arturo Extension Enabled|
|-------------------------|------------------------|
|![Icons works great](https://github.com/user-attachments/assets/e092e324-7f93-4a49-ad03-313e8b9074d6)|![Default icons replaced](https://github.com/user-attachments/assets/1cb2849f-954b-414e-b37f-5f9234fd7aa0)|