### PR TITLE
Refactor: Custom Error Handling and Query builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arturo",
   "displayName": "Arturo",
   "description": "Syntax highlighting for the Arturo programming language",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "publisher": "drkameleon",
   "repository": "https://github.com/arturo-lang/vscode-extension",
   "icon": "icons/gray.png",

--- a/src/commands/helper/error.ts
+++ b/src/commands/helper/error.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode'
+
+export class Warning extends Error {
+    constructor(public message: string) {
+        super(message)
+        this.name = 'Warning'
+    }
+}
+
+interface EnsureArgs<T> {
+    that: T | (() => T)
+    reason: string | string[]
+    as?: 'warning' | 'error'
+}
+
+function isSupplier<T>(x: T | (() => T)): x is () => T {
+    return typeof x === 'function'
+}
+
+export const ensure = <T>(args: EnsureArgs<T | null>): NonNullable<T> => {
+    const value = isSupplier(args.that)
+        ? (args.that as () => T )()
+        : (args.that as T)
+    const as = args.as ?? 'warning'
+    const reason = Array.isArray(args.reason) ? args.reason.join('\n') : args.reason
+
+    if (value === null || value === undefined || !value) {
+        if (as === 'warning') {
+            throw new Warning(reason)
+        } else {
+            throw new Error(reason)
+        }
+    } else {
+        return value as NonNullable<T>
+    }
+}
+
+const handle = (error: unknown) => {
+    if (error instanceof Warning) {
+        vscode.window.showWarningMessage(error.message)
+    } else if (error instanceof Error) {
+        vscode.window.showErrorMessage(error.message)
+    } else {
+        vscode.window.showErrorMessage('An unexpected error occurred.')
+    }
+}
+
+export const withNotify = <T extends (...args: any[]) => any>(fn: T): T => {
+    const wrapped = async function (this: unknown, ...args: Parameters<T>): Promise<ReturnType<T> | void> {
+        try {
+            return await fn.apply(this, args)
+        } catch (error) {
+            handle(error)
+        }
+    }
+
+    return wrapped as unknown as T
+}

--- a/src/commands/helper/error.ts
+++ b/src/commands/helper/error.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+/** Represents a warning condition. */
 export class Warning extends Error {
     constructor(public message: string) {
         super(message)
@@ -13,10 +14,15 @@ interface EnsureArgs<T> {
     as?: 'warning' | 'error'
 }
 
+/** Type guard to check if a value is a supplier function. */
 function isSupplier<T>(x: T | (() => T)): x is () => T {
     return typeof x === 'function'
 }
 
+/** Ensures that a value is not null, undefined, or falsy.
+ * 
+ * If the value is invalid, throws an error or warning with the provided reason.
+ */
 export const ensure = <T>(args: EnsureArgs<T | null>): NonNullable<T> => {
     const value = isSupplier(args.that)
         ? (args.that as () => T )()
@@ -35,6 +41,7 @@ export const ensure = <T>(args: EnsureArgs<T | null>): NonNullable<T> => {
     }
 }
 
+/** Handles an error by showing an appropriate message to the user. */
 const handle = (error: unknown) => {
     if (error instanceof Warning) {
         vscode.window.showWarningMessage(error.message)
@@ -45,6 +52,7 @@ const handle = (error: unknown) => {
     }
 }
 
+/** Wraps a function to automatically notify the user of errors.*/
 export const withNotify = <T extends (...args: any[]) => any>(fn: T): T => {
     const wrapped = async function (this: unknown, ...args: Parameters<T>): Promise<ReturnType<T> | void> {
         try {

--- a/src/commands/helper/github.ts
+++ b/src/commands/helper/github.ts
@@ -1,0 +1,42 @@
+
+
+const encodeQuery = (params: Record<string, string>): string => {
+    return Object.entries(params)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+        .join('&')
+}
+
+interface GithubUrlParams {
+    owner: string
+    repo: string
+    path?: string
+    query?: Record<string, string>
+}
+
+
+export class GithubUrl {
+    constructor(private params: GithubUrlParams) {}
+
+    public withPath(path: string): GithubUrl {
+        return new GithubUrl({
+            ...this.params,
+            path
+        })
+    }
+
+    public withQuery(query: Record<string, string>): GithubUrl {
+        return new GithubUrl({
+            ...this.params,
+            query
+        })
+    }
+
+    public toString(): string {
+        const { owner, repo, path, query } = this.params
+        let url = `https://github.com/${owner}/${repo}`
+        if (path)  url += `/${path}`
+        if (query) url += `?${encodeQuery(query)}`
+        return url
+    }
+
+}

--- a/src/commands/helper/system.ts
+++ b/src/commands/helper/system.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs'
 import * as os from 'os'
 
+import * as vscode from 'vscode'
+
 /** Retrieves the Linux distribution name from /etc/os-release. */
 const getDistro = () => {
     try {
@@ -17,4 +19,15 @@ export const osInfo = () => {
     const distro = getDistro()
     const osLine = `${os.type()} ${distro ? ' - ' + distro : ''}`
     return osLine
+}
+
+export const vscodeInfo = () => {
+    const appName = vscode.env.appName || 'unknown'
+    const vscodeVersion = (vscode as any).version || 'unknown'
+
+    return `${appName} ${vscodeVersion}`
+}
+
+export const extensionVersion = () => {
+    return vscode.extensions.getExtension('drkameleon.arturo')?.packageJSON?.version || 'unknown'
 }

--- a/src/commands/meta.ts
+++ b/src/commands/meta.ts
@@ -12,7 +12,7 @@ import * as vscode from 'vscode'
 import { arturoVersion } from './helper/arturo'
 import { GithubUrl } from './helper/github'
 import { ensure } from './helper/error'
-import { osInfo } from './helper/system'
+import { extensionVersion, osInfo, vscodeInfo } from './helper/system'
 
 /** Opens the Arturo GitHub issues page to report a new issue.
  * 
@@ -40,13 +40,9 @@ export const reportIssue = async () => {
         as: 'error'
     })
 
-    const appName = vscode.env.appName || 'unknown'
-    const vscodeVersion = (vscode as any).version || 'unknown'
-    const extensionVersion = vscode.extensions.getExtension('drkameleon.arturo')?.packageJSON?.version || 'unknown'
-
     const context = [
         'Issue reported from official Arturo\'s VS Code extension.',
-        `- VS Code: ${appName} ${vscodeVersion} / Extension: v${extensionVersion}`
+        `- VS Code: ${vscodeInfo()} / Extension: v${extensionVersion()}`
     ].join('\n')
     
     const url = new GithubUrl({ owner: 'arturo-lang', repo: 'arturo' })

--- a/src/commands/meta.ts
+++ b/src/commands/meta.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode'
 
 import { arturoVersion } from './helper/arturo'
 import { GithubUrl } from './helper/github'
-import { ensure,  withNotify } from './helper/error'
+import { ensure } from './helper/error'
 import { osInfo } from './helper/system'
 
 /** Opens the Arturo GitHub issues page to report a new issue.
@@ -19,7 +19,7 @@ import { osInfo } from './helper/system'
  * Pre-fills the issue title and body with system information to help
  * with debugging.
  */
-export const reportIssue = withNotify(async () => {
+export const reportIssue = async () => {
     const template = 'bug-report.yaml'
 
     const title: string = ensure({
@@ -60,7 +60,7 @@ export const reportIssue = withNotify(async () => {
         })
 
     vscode.env.openExternal(vscode.Uri.parse(url.toString()))
-})
+}
 
 /** Opens the Arturo documentation in a webview panel.
  * 

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -5,21 +5,26 @@
 
 import { ask } from './helper/ui'
 import { arturo } from './helper/arturo'
+import { ensure } from './helper/error'
 
 /** Asks the user for a package name to install. */
 export const install = async () => {
-    const packageName = await ask('Enter the name of the package to install:')
-    if (!packageName) return
+    const name: string = ensure({
+        that: await ask('Enter the name of the package to install:'),
+        reason: 'Package name is required to install a package.',
+    })
 
-    arturo("Package Manager", `--package install ${packageName}`)
+    arturo("Package Manager", `--package install ${name}`)
 }
 
 /** Asks the user for a package name to uninstall. */
 export const uninstall = async () => {
-    const packageName = await ask('Enter the name of the package to uninstall:')
-    if (!packageName) return
+    const name: string = ensure({
+        that: await ask('Enter the name of the package to uninstall:'),
+        reason: 'Package name is required to uninstall a package.',
+    })
 
-    arturo("Package Manager", `--package uninstall ${packageName}`)
+    arturo("Package Manager", `--package uninstall ${name}`)
 }
 
 /** Lists all installed packages. */

--- a/src/commands/runtime.ts
+++ b/src/commands/runtime.ts
@@ -22,8 +22,10 @@ export const openRepl = () => {
  * If no file is selected, the function exits without action.
  * */
 export const runFile = async () => {
-    const file = await selectScript()
-    if (!file) return
+    const file: string = ensure({
+        that: await selectScript(),
+        reason: 'No Arturo file selected to run.',
+    })
 
     await runWithDiagnostics(file)
 }

--- a/src/commands/runtime.ts
+++ b/src/commands/runtime.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode'
 import {selectScript} from './helper/ui'
 import { arturo } from './helper/arturo'
 import { runWithDiagnostics } from './helper/diagnostics'
+import { ensure } from './helper/error'
 
 
 /** Opens the Arturo REPL in a new terminal window. */
@@ -34,27 +35,26 @@ export const runFile = async () => {
  * If the file is unsaved or has unsaved changes, it prompts to save before running.
  */
 export const runCurrentFile = async () => {
-    const editor = vscode.window.activeTextEditor
 
-    if (!editor) {
-        vscode.window.showWarningMessage('No active editor to run.')
-        return
-    }
+    const editor = ensure({
+        that: vscode.window.activeTextEditor,
+        reason: 'No active editor to run.',
+    })
 
-    const doc = editor.document
-    if (doc.languageId !== 'art' && !doc.fileName.toLowerCase().endsWith('.art')) {
-        vscode.window.showWarningMessage('Open an Arturo file to run it.')
-        return
-    }
+    ensure({
+        that: editor.document.languageId == 'art',
+        reason: 'Open an Arturo file to run it.',
+    })
 
-    if (doc.isUntitled) {
-        vscode.window.showWarningMessage('Save the Arturo file before running it.')
-        return
-    }
+    ensure({
+        that: !editor.document.isUntitled,
+        reason: 'Save the Arturo file before running it.'
+    })
 
-    if (doc.isDirty) await doc.save()
+    if (editor.document.isDirty) 
+        await editor.document.save()
 
-    runWithDiagnostics(doc.fileName)
+    runWithDiagnostics(editor.document.fileName)
 }
 
 /** Prompts the user to select an Arturo script and bundles it.

--- a/src/commands/runtime.ts
+++ b/src/commands/runtime.ts
@@ -63,8 +63,10 @@ export const runCurrentFile = async () => {
  * If no file is selected, the function exits without action.
  */
 export const bundleFile = async () => {
-    const file = await selectScript()
-    if (!file) return
+    const file = ensure({
+        that: await selectScript(),
+        reason: 'No Arturo file selected to bundle.',
+    })
 
     const asName = await vscode.window.showInputBox({
         prompt: 'Enter the bundle name',

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,5 +1,7 @@
 import * as vscode from "vscode"
 
+import { withNotify } from "./commands/helper/error"
+
 /** Type alias for VS Code ExtensionContext for easier usage. */
 export type Context = vscode.ExtensionContext
 
@@ -14,6 +16,6 @@ export type Context = vscode.ExtensionContext
  * @param action - The function to execute when the command is invoked.
 */
 export const command = (ctx: Context, id: string, action: () => void) => {
-    const disposable = vscode.commands.registerCommand(id, action)
+    const disposable = vscode.commands.registerCommand(id, withNotify(action))
     ctx.subscriptions.push(disposable)
 }


### PR DESCRIPTION
That is a refactor of mine to use a custom error handling and query builder. 

Basically we have two exceptions `Error` and `Warning`, the function `ensure` raises them when some value is false, null or undefined.

If the expected does not match, we raise this exception and shows it as a Vs Code message.

For the query builder, I am using fluent interface on `GithubUrl`.

