### PR TITLE
[Commands\Package Manager] Smart Package management

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "onCommand:arturo.meta.open-docs",
     "onCommand:arturo.package.install",
     "onCommand:arturo.package.uninstall",
-    "onCommand:arturo.package.list",
-    "onCommand:arturo.package.remote",
     "onCommand:arturo.package.update"
   ],
   "categories": [
@@ -61,14 +59,6 @@
       {
         "command": "arturo.package.uninstall",
         "title": "Arturo: Uninstall Package"
-      },
-      {
-        "command": "arturo.package.list",
-        "title": "Arturo: List Installed Packages"
-      },
-      {
-        "command": "arturo.package.remote",
-        "title": "Arturo: List Registered Packages"
       },
       {
         "command": "arturo.package.update",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
         "title": "Arturo: Open Documentation"
       },
       {
+        "command": "arturo.package.open-docs",
+        "title": "Arturo: Open Package Documentation"
+      },
+      {
         "command": "arturo.package.install",
         "title": "Arturo: Install Package"
       },

--- a/package.json
+++ b/package.json
@@ -53,20 +53,8 @@
         "title": "Arturo: Open Documentation"
       },
       {
-        "command": "arturo.package.open-docs",
-        "title": "Arturo: Open Package Documentation"
-      },
-      {
-        "command": "arturo.package.install",
-        "title": "Arturo: Install Package"
-      },
-      {
-        "command": "arturo.package.uninstall",
-        "title": "Arturo: Uninstall Package"
-      },
-      {
-        "command": "arturo.package.update",
-        "title": "Arturo: Update All Packages"
+        "command": "arturo.package.manage",
+        "title": "Arturo: Manage Packages"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "onCommand:arturo.runtime.bundle",
     "onCommand:arturo.meta.report-issue",
     "onCommand:arturo.meta.open-docs",
-    "onCommand:arturo.package.install",
-    "onCommand:arturo.package.uninstall",
-    "onCommand:arturo.package.update"
+    "onCommand:arturo.package.manage",
   ],
   "categories": [
     "Programming Languages"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "onCommand:arturo.runtime.bundle",
     "onCommand:arturo.meta.report-issue",
     "onCommand:arturo.meta.open-docs",
-    "onCommand:arturo.package.manage",
+    "onCommand:arturo.package.manage"
   ],
   "categories": [
     "Programming Languages"

--- a/src/commands/helper/packages.ts
+++ b/src/commands/helper/packages.ts
@@ -1,0 +1,42 @@
+import * as vscode from "vscode"
+
+import { execSync } from "child_process"
+import { ensure } from "./error"
+
+/**
+ * Parse the tabular output of arturo and return only package names.
+ */
+const parsePackageList = (raw: string): string[] => {
+    const entry = /^\s*[-*]\s+([^\s]+)\s+/
+
+    return raw
+        .split(/\r?\n/)
+        .filter(line => line.startsWith('- ') || line.startsWith('* '))
+        .map(line => entry.exec(line))
+        .filter((match): match is RegExpExecArray => !!match)
+        .map(match => match[1].trim())
+}
+
+/** Lists all installed packages. */
+export const installed = async () =>
+    parsePackageList(execSync('arturo --package list', { encoding: 'utf-8' }))
+
+/** Lists all registered remote packages. */
+export const registered = async () => 
+        parsePackageList(execSync('arturo --package remote', { encoding: 'utf-8' }))
+
+export const selectPackage = async (
+    packages: string[],
+    placeholder: string,
+): Promise<string | null> => {
+    ensure({
+        that: packages.length > 0,
+        reason: 'No packages available for selection.'
+    })
+
+    const selection = await vscode.window.showQuickPick(packages, {
+        placeHolder: placeholder
+    })
+
+    return selection ?? null
+}

--- a/src/commands/helper/ui.ts
+++ b/src/commands/helper/ui.ts
@@ -29,3 +29,34 @@ export const ask = async (prompt: string): Promise<string | null> => {
     })
     return (input === undefined) ? null : input
 }
+
+interface OpenDocsArgs {
+    url: string,
+    title: string
+}
+
+/** Opens some page in a webview panel.
+ * 
+ * If the webview cannot be created, it falls back to opening
+ * the documentation in the default web browser.
+ */
+export const openPage = (args: OpenDocsArgs) => {
+    try {
+        const panel = vscode.window.createWebviewPanel(
+            args.title.replace(/\s+/g, '-').toLowerCase(),
+            args.title,
+            vscode.ViewColumn.Beside,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true
+            }
+        )
+
+        panel.webview.html = `<!doctype html>
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; frame-src https:; style-src 'unsafe-inline';">
+            <style>html,body,iframe{height:100%;width:100%;margin:0;padding:0;border:0}</style>
+            <iframe src="${args.url}" frameBorder="0" style="width:100%;height:100%;"></iframe>`
+    } catch (e) {
+        vscode.env.openExternal(vscode.Uri.parse(args.url))
+    }
+}

--- a/src/commands/meta.ts
+++ b/src/commands/meta.ts
@@ -13,6 +13,7 @@ import { arturoVersion } from './helper/arturo'
 import { GithubUrl } from './helper/github'
 import { ensure } from './helper/error'
 import { extensionVersion, osInfo, vscodeInfo } from './helper/system'
+import { openPage } from './helper/ui'
 
 /** Opens the Arturo GitHub issues page to report a new issue.
  * 
@@ -64,24 +65,8 @@ export const reportIssue = async () => {
  * the documentation in the default web browser.
  */
 export const openDocs = () => {
-    const url = 'https://arturo-lang.io/latest/documentation/library'
-
-    try {
-        const panel = vscode.window.createWebviewPanel(
-            'arturoDocs',
-            'Arturo Documentation',
-            vscode.ViewColumn.Beside,
-            {
-                enableScripts: true,
-                retainContextWhenHidden: true
-            }
-        )
-
-        panel.webview.html = `<!doctype html>
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; frame-src https:; style-src 'unsafe-inline';">
-            <style>html,body,iframe{height:100%;width:100%;margin:0;padding:0;border:0}</style>
-            <iframe src="${url}" frameBorder="0" style="width:100%;height:100%;"></iframe>`
-    } catch (e) {
-        vscode.env.openExternal(vscode.Uri.parse(url))
-    }
+    openPage({
+        url: 'https://arturo-lang.io/latest/documentation/library',
+        title: 'Arturo Documentation'
+    })
 }

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -4,12 +4,60 @@
  */
 
 
+import * as vscode from 'vscode'
+
 import { arturo } from './helper/arturo'
 import { ensure } from './helper/error'
 import { openPage } from './helper/ui'
 import { installed, registered, selectPackage } from './helper/packages'
 
-export const openPackageDocs = async () => {
+type PackageAction = 'install' | 'uninstall' | 'update' | 'docs'
+
+interface ActionQuickPickItem extends vscode.QuickPickItem {
+    value: PackageAction
+}
+
+const pickAction = async (): Promise<ActionQuickPickItem> => {
+    const action = await vscode.window.showQuickPick<ActionQuickPickItem>([
+        { label: 'Install package', description: 'Fetch from registry', value: 'install' },
+        { label: 'Uninstall package', description: 'Remove from local environment', value: 'uninstall' },
+        { label: 'Update packages', description: 'Upgrade all installed packages', value: 'update' },
+        { label: 'Open package docs', description: 'View documentation for a package', value: 'docs' },
+    ], {
+        placeHolder: 'What would you like to do with Arturo packages?'
+    })
+
+    return ensure({
+        that: action,
+        reason: 'Package action selection is required.'
+    })
+}
+
+const installPackage = async () => {
+    const message = 'Select a package to install'
+    const name: string = ensure({
+        that: await selectPackage(await registered(), message),
+        reason: 'Package selection is required to install a package.'
+    })
+
+    arturo('Package Manager', `--package install ${name}`)
+}
+
+const uninstallPackage = async () => {
+    const message = 'Select a package to uninstall'
+    const name: string = ensure({
+        that: await selectPackage(await installed(), message),
+        reason: 'Package selection is required to uninstall a package.'
+    })
+
+    arturo('Package Manager', `--package uninstall ${name}`)
+}
+
+const updatePackages = async () => {
+    arturo('Package Manager', '--package update')
+}
+
+const openPackageDocs = async () => {
     const message = 'Select a package to view documentation'
     const name: string = ensure({
         that: await selectPackage(await registered(), message),
@@ -22,30 +70,16 @@ export const openPackageDocs = async () => {
     })
 }
 
+/** Guides the user through package management actions. */
+export const managePackages = async () => {
+    const { value } = await pickAction()
 
-/** Asks the user for a package name to install. */
-export const install = async () => {
-    const message = 'Select a package to install'
-    const name: string = ensure({
-        that: await selectPackage(await registered(), message),
-        reason: 'Package selection is required to install a package.'
-    })
+    const options = {
+        install: installPackage,
+        uninstall: uninstallPackage,
+        update: updatePackages,
+        docs: openPackageDocs
+    }
 
-    arturo('Package Manager', `--package install ${name}`)
-}
-
-/** Asks the user for a package name to uninstall. */
-export const uninstall = async () => {
-    const message = 'Select a package to uninstall'
-    const name: string = ensure({
-        that: await selectPackage(await installed(), message),
-        reason: 'Package selection is required to uninstall a package.'
-    })
-
-    arturo('Package Manager', `--package uninstall ${name}`)
-}
-
-/** Updates all installed packages to their latest versions. */
-export const updateAll = async () => {
-    arturo("Package Manager", `--package update`)
+    options[value]()
 }

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -3,51 +3,11 @@
  * @fileoverview Arturo Package Manager related commands.
  */
 
-import * as vscode from 'vscode'
 
 import { arturo } from './helper/arturo'
 import { ensure } from './helper/error'
-import { execSync } from 'child_process'
 import { openPage } from './helper/ui'
-
-/**
- * Parse the tabular output of arturo and return only package names.
- */
-const parsePackageList = (raw: string): string[] => {
-    const entry = /^\s*[-*]\s+([^\s]+)\s+/
-
-    return raw
-        .split(/\r?\n/)
-        .filter(line => line.startsWith('- ') || line.startsWith('* '))
-        .map(line => entry.exec(line))
-        .filter((match): match is RegExpExecArray => !!match)
-        .map(match => match[1].trim())
-}
-
-/** Lists all installed packages. */
-const installed = async () =>
-    parsePackageList(execSync('arturo --package list', { encoding: 'utf-8' }))
-
-/** Lists all registered remote packages. */
-const registered = async () => 
-        parsePackageList(execSync('arturo --package remote', { encoding: 'utf-8' }))
-
-const selectPackage = async (
-    packages: string[],
-    placeholder: string,
-): Promise<string | null> => {
-    ensure({
-        that: packages.length > 0,
-        reason: 'No packages available for selection.'
-    })
-
-    const selection = await vscode.window.showQuickPick(packages, {
-        placeHolder: placeholder
-    })
-
-    return selection ?? null
-}
-
+import { installed, registered, selectPackage } from './helper/packages'
 
 export const openPackageDocs = async () => {
     const message = 'Select a package to view documentation'

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -50,12 +50,9 @@ const selectPackage = async (
 
 /** Asks the user for a package name to install. */
 export const install = async () => {
+    const message = 'Select a package to install'
     const name: string = ensure({
-        that: await selectPackage(
-            await registered(),
-            'Select a package to install',
-            'No registered packages found.'
-        ),
+        that: await selectPackage(await registered(), message),
         reason: 'Package selection is required to install a package.'
     })
 
@@ -64,12 +61,9 @@ export const install = async () => {
 
 /** Asks the user for a package name to uninstall. */
 export const uninstall = async () => {
+    const message = 'Select a package to uninstall'
     const name: string = ensure({
-        that: await selectPackage(
-            await installed(),
-            'Select a package to uninstall',
-            'No installed packages found.'
-        ),
+        that: await selectPackage(await installed(), message),
         reason: 'Package selection is required to uninstall a package.'
     })
 

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -74,12 +74,12 @@ const openPackageDocs = async () => {
 export const managePackages = async () => {
     const { value } = await pickAction()
 
-    const options = {
+    const options: Record<PackageAction, () => Promise<void>> = {
         install: installPackage,
         uninstall: uninstallPackage,
         update: updatePackages,
         docs: openPackageDocs
     }
 
-    options[value]()
+    await options[value]()
 }

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode'
 import { arturo } from './helper/arturo'
 import { ensure } from './helper/error'
 import { execSync } from 'child_process'
+import { openPage } from './helper/ui'
 
 /**
  * Parse the tabular output of arturo and return only package names.
@@ -45,6 +46,20 @@ const selectPackage = async (
     })
 
     return selection ?? null
+}
+
+
+export const openPackageDocs = async () => {
+    const message = 'Select a package to view documentation'
+    const name: string = ensure({
+        that: await selectPackage(await registered(), message),
+        reason: 'Package selection is required to view documentation.'
+    })
+
+    openPage({
+        url: `https://${name}.pkgr.art`,
+        title: `Package: ${name} Documentation`
+    })
 }
 
 

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -22,6 +22,15 @@ const parsePackageList = (raw: string): string[] => {
         .map(match => match[1].trim())
 }
 
+/** Lists all installed packages. */
+const installed = async () =>
+    parsePackageList(execSync('arturo --package list', { encoding: 'utf-8' }))
+
+/** Lists all registered remote packages. */
+const registered = async () => 
+        parsePackageList(execSync('arturo --package remote', { encoding: 'utf-8' }))
+
+
 /** Asks the user for a package name to install. */
 export const install = async () => {
     const name: string = ensure({
@@ -40,20 +49,6 @@ export const uninstall = async () => {
     })
 
     arturo("Package Manager", `--package uninstall ${name}`)
-}
-
-/** Lists all installed packages. */
-export const installed = async () => {
-    const output = execSync('arturo --package list', { encoding: 'utf-8' })
-    const list = parsePackageList(output)
-    console.log(list)
-}
-
-/** Lists all registered remote packages. */
-export const registered = async () => {
-    const output = execSync('arturo --package remote', { encoding: 'utf-8' })
-    const list = parsePackageList(output)
-    console.log(list)
 }
 
 /** Updates all installed packages to their latest versions. */

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -6,6 +6,21 @@
 import { ask } from './helper/ui'
 import { arturo } from './helper/arturo'
 import { ensure } from './helper/error'
+import { execSync } from 'child_process'
+
+/**
+ * Parse the tabular output of arturo and return only package names.
+ */
+const parsePackageList = (raw: string): string[] => {
+    const entry = /^\s*[-*]\s+([^\s]+)\s+/
+
+    return raw
+        .split(/\r?\n/)
+        .filter(line => line.startsWith('- ') || line.startsWith('* '))
+        .map(line => entry.exec(line))
+        .filter((match): match is RegExpExecArray => !!match)
+        .map(match => match[1].trim())
+}
 
 /** Asks the user for a package name to install. */
 export const install = async () => {
@@ -29,12 +44,16 @@ export const uninstall = async () => {
 
 /** Lists all installed packages. */
 export const installed = async () => {
-    arturo("Package Manager", `--package list`)
+    const output = execSync('arturo --package list', { encoding: 'utf-8' })
+    const list = parsePackageList(output)
+    console.log(list)
 }
 
 /** Lists all registered remote packages. */
 export const registered = async () => {
-    arturo("Package Manager", `--package remote`)
+    const output = execSync('arturo --package remote', { encoding: 'utf-8' })
+    const list = parsePackageList(output)
+    console.log(list)
 }
 
 /** Updates all installed packages to their latest versions. */

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -34,7 +34,6 @@ const registered = async () =>
 const selectPackage = async (
     packages: string[],
     placeholder: string,
-    emptyMessage: string
 ): Promise<string | null> => {
     ensure({
         that: packages.length > 0,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import { command, Context } from "./helper"
 
 import { bundleFile, openRepl, runCurrentFile, runFile } from "./commands/runtime"
 import { openDocs, reportIssue } from "./commands/meta"
-import { install, uninstall, updateAll } from "./commands/package"
+import { install, openPackageDocs, uninstall, updateAll } from "./commands/package"
 
 
 /** Register commands for the Arturo VS Code extension on activate.
@@ -16,6 +16,7 @@ export const activate = (context: Context) => {
     command(context, "arturo.runtime.run-current", runCurrentFile)
     command(context, "arturo.runtime.bundle", bundleFile)
 
+    command(context, "arturo.package.open-docs", openPackageDocs)
     command(context, "arturo.package.install", install)
     command(context, "arturo.package.uninstall", uninstall)
     command(context, "arturo.package.update", updateAll)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import { command, Context } from "./helper"
 
 import { bundleFile, openRepl, runCurrentFile, runFile } from "./commands/runtime"
 import { openDocs, reportIssue } from "./commands/meta"
-import { install, installed, registered, uninstall, updateAll } from "./commands/package"
+import { install, uninstall, updateAll } from "./commands/package"
 
 
 /** Register commands for the Arturo VS Code extension on activate.
@@ -18,8 +18,6 @@ export const activate = (context: Context) => {
 
     command(context, "arturo.package.install", install)
     command(context, "arturo.package.uninstall", uninstall)
-    command(context, "arturo.package.list", installed)
-    command(context, "arturo.package.remote", registered)
     command(context, "arturo.package.update", updateAll)
 
     command(context, "arturo.meta.report-issue", reportIssue)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import { command, Context } from "./helper"
 
 import { bundleFile, openRepl, runCurrentFile, runFile } from "./commands/runtime"
 import { openDocs, reportIssue } from "./commands/meta"
-import { install, openPackageDocs, uninstall, updateAll } from "./commands/package"
+import { managePackages } from "./commands/package"
 
 
 /** Register commands for the Arturo VS Code extension on activate.
@@ -16,10 +16,7 @@ export const activate = (context: Context) => {
     command(context, "arturo.runtime.run-current", runCurrentFile)
     command(context, "arturo.runtime.bundle", bundleFile)
 
-    command(context, "arturo.package.open-docs", openPackageDocs)
-    command(context, "arturo.package.install", install)
-    command(context, "arturo.package.uninstall", uninstall)
-    command(context, "arturo.package.update", updateAll)
+    command(context, "arturo.package.manage", managePackages)
 
     command(context, "arturo.meta.report-issue", reportIssue)
     command(context, "arturo.meta.open-docs", openDocs)


### PR DESCRIPTION
## At a Glance

https://github.com/user-attachments/assets/293a916e-ec12-4e5f-b95e-396c31fa4e21
- Now we have a single command with sub-commands:
  - Install: lists all available packages in registry, then you choose which one to install.
  - Uninstall: lists all installed packages, then you choose which one to uninstall.
  - Read Documentation: lists all packages in registry, you choose which one to open.
  - Update: updates all packages, the output is shown on terminal.

## Explanation

Instead of make it a simple proxy for our CLI, I decided to improve the way we interact with this feature.

First, I decided to merge all commands into a single one. It makes easier to find what we want to do. So instead of having 6 commands when I type "Package", I have a single one. Instead of listing my local packages, copy its name and then paste on the uninstall command, now, I can just choose uninstall.

The new commands are smart and anti-typo. So, no worries with copy and paste or typing the package's name wrong. Install and Documentation lists all packages available in our registry and Uninstall lists all local packages. You can search the packages, but you choose which one to interact instead of writting its name.